### PR TITLE
Update index.html to fix changelog link

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                 The Impact client is an <b>advanced</b> utility mod for Minecraft, it is based on <b>ClientAPI</b> and includes a large number of <b>useful mods</b>
             </p>
             <p class="col s12 center med_text">
-                You can view a list of past and upcoming changes <a href="/changelog" target="_blank">here</a>.
+                You can view a list of past and upcoming changes <a href="/Impact/changelog" target="_blank">here</a>.
             </p>
         </div>
     </div>


### PR DESCRIPTION
When you click on the button that allows redirects you to the changelog, you go to https://impactdevelopment.github.io/changelog, and that redirects you to https://impactdevelopment.github.io/Impact/changelog. Updated index.html so you go directly to https://impactdevelopment.github.io/Impact/changelog.